### PR TITLE
Streamline compression and read interface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,12 +11,14 @@ MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 ProtoBuf = "3349acd9-ac6a-5e09-bcdb-63829b23a429"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 
 [compat]
 BufferedStreams = "1.0"
 CodecZlib = "0.7"
 MacroTools = "0.5"
 ProtoBuf = "0.10, 0.11"
+TranscodingStreams = "0.9"
 julia = "1.5"
 
 [extras]


### PR DESCRIPTION
This PR streamlines the compression and read interface by

- using `TranscodingStreams.NoopStream` for uncompressed streams
- using `===` to compare the compression symbol to admit const propagation
- simplifying the interface for handing multiple files and potential transformations to `read`.